### PR TITLE
chore: 🤖 add fleek testnet to dfx.json

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -1,16 +1,20 @@
 {
-	"canisters": {
-		"wicp": {
-			"package": "wicp",
-			"candid": "wicp/wicp.did",
-			"type": "rust"
-		}
-	},
-	"networks": {
-		"local": {
-			"bind": "127.0.0.1:8000",
-			"type": "ephemeral"
-		}
-	},
-	"version": 1
+  "canisters": {
+    "wicp": {
+      "package": "wicp",
+      "candid": "wicp/wicp.did",
+      "type": "rust"
+    }
+  },
+  "networks": {
+    "local": {
+      "bind": "127.0.0.1:8000",
+      "type": "ephemeral"
+    },
+    "fleek-testnet": {
+      "bind": "34.216.56.80:8080",
+      "type": "ephemeral"
+    }
+  },
+  "version": 1
 }


### PR DESCRIPTION
## Why?

The dfx.json should have the fleek testnet, as it'll be required for automating deployments e.g. staging https://github.com/Psychedelic/nft-marketplace-fe/pull/71 which depends on this PR

## How?

- Add feek testnet network to dfx.json
