### PR TITLE
chore: 🤖 add fleek testnet to canister_ids.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 
 # dfx temporary files
 .dfx/
-canister_ids.json
 # state icx-proxy-pid webserver-port replica-configuration
 
 # frontend code

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,0 +1,5 @@
+{
+  "wicp": {
+    "fleek-testnet": "y4drz-waaaa-aaaaa-aabrq-cai"
+  }
+}


### PR DESCRIPTION
## Why?

The reason why I'd want to use it, is that I'd like to persist the canister id when deploying to the fleek remote replica, which wicp and other services are deployed for the marketplace project. Here's the source https://github.com/Psychedelic/wicp/blob/main/.gitignore#L12 and let me know if I should handle this separately or if I can indeed add to the original repo.

## How?

- adds canister_ids.json
