### PR TITLE
chore: 🤖 add mainnet location to canister id

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,5 +1,6 @@
 {
   "wicp": {
+    "ic": "utozz-siaaa-aaaam-qaaxq-cai",
     "fleek-testnet": "y4drz-waaaa-aaaaa-aabrq-cai"
   }
 }


### PR DESCRIPTION
## Why?

Communicate clearly where the mainnet wicp is located at by adding to the canister ids json file.

## Demo?

Optionally, provide any screenshot, gif or small video.
